### PR TITLE
Correcting and unifying the test running usage

### DIFF
--- a/ibeis/__init__.py
+++ b/ibeis/__init__.py
@@ -337,12 +337,13 @@ Regen Command:
 """
 
 if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m ibeis
-        python -m ibeis --allexamples
+    """
+    Runs the unittests for the ibeis codebase
+
+    Commandline usage: python -m ibeis
+
     """
     import multiprocessing
     multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-    ut.doctest_funcs()
+    from ibeis.tests.run_tests import run_tests
+    run_tests()

--- a/ibeis/tests/run_tests.py
+++ b/ibeis/tests/run_tests.py
@@ -306,22 +306,14 @@ def convert_tests_from_ibeis_to_nose(module_list):
     moddir = ut.get_module_dir(tests)
     ut.writeto(join(moddir, 'test_autogen_nose_tests.py'), autogen_test_src)
 
-#if __name__ == '__main__':
-#    """
-#    python -m ibeis --run-tests
-#    """
-#    import multiprocessing
-#    multiprocessing.freeze_support()
-#    run_tests()
-
 
 if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m ibeis.tests.run_tests
-        python -m ibeis.tests.run_tests --allexamples
+    """
+    Run the unit tests for IBEIS
+
+    Commandline usage: python -m ibeis.tests.run_tests
+
     """
     import multiprocessing
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-    ut.doctest_funcs()
+    multiprocessing.freeze_support()
+    run_tests()

--- a/ibeis/web/test_api.py
+++ b/ibeis/web/test_api.py
@@ -7,6 +7,9 @@ import utool as ut
 import hmac
 import requests
 
+import utool as ut
+
+
 (print, rrr, profile) = ut.inject2(__name__)
 
 # System variables


### PR DESCRIPTION
This is a simple set of changes that I made while attempting to run the tests. I noticed the inconsistency between running the tests via the `ibeis` package, `ibeis.tests.run_tests` module and `run_tests.py` script. They now all run the same set of tests.

I've also corrected a `NameError` in one of the test modules.