### PR TITLE
Add pre-commit for linting and automatic code correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ models*/
 docker/dev/
 
 *.backup
+
+# Add an exception for .pre-commit-config.yaml
+!.pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+      # - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.1
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -199,7 +199,14 @@ baseline_neighbor_filter in the module ibeis.algo.hots.pipeline:
     python -m ibeis.algo.hots.pipeline --test-baseline_neighbor_filter:0
     
 
-# Code Style Guidelines
+# Code Style and Development Guidelines
+
+## Contributing
+
+It's recommended that you use `pre-commit` to ensure linting procedures are run
+on any commit you make. (See also (pre-commit.com)[https://pre-commit.com/])
+
+Reference (pre-commit's installation instructions)[https://pre-commit.com/#install] for software installation on your OS/platform. After you have the software installed, run `pre-commit install` on the commandline. Now everytime you commit to this project's codebase the linter procedures will automatically run over the changed files.
 
 For Python try to conform to pep8. 
 You should set up your preferred editor to use flake8 as linter.


### PR DESCRIPTION
The pre-commit utility is a git commit hook utility for taking action
on commited changes. For example, one of it's primarily uses is for
linting changes.

In this case, I've configured it with two hooks: end-of-file-fixer &
flake8. When pre-commit has been installed by the developer, these two
utilities will run when on any changed files within the commit. It
will also block the commit if their are errors.

In some cases hooks have been created to fix errors and proceed with
the commit. In others it requires user verification before
proceeding.

This commit is being created so that we are able to automate the
stylistic review of code. Thus, giving the reviewer ample freedom to
look beyond style when reviewing changes.

---

The `astyle` linter can be set up in this at some point. I'd imagine sooner rather than later we'll put a `Dockerfile` linter into this as well. 