### PR TITLE
Fix dtool and plottool imports

### DIFF
--- a/ibeis/guitool/PreferenceWidget.py
+++ b/ibeis/guitool/PreferenceWidget.py
@@ -356,7 +356,7 @@ def test_preference_gui():
         >>> ut.quit_if_noshow()
         >>> guitool.qtapp_loop(freq=10)
     """
-    import dtool
+    from ibeis import dtool
     class DtoolConfig(dtool.Config):
         _param_info_list = [
             ut.ParamInfo('str_option2', 'hello'),

--- a/ibeis/plottool/__init__.py
+++ b/ibeis/plottool/__init__.py
@@ -13,35 +13,35 @@ ut.noinject(__name__, '[plottool.__init__]')
 # Hopefully this was imported sooner. TODO remove dependency
 #from ibeis.guitool import __PYQT__
 #import ibeis.guitool.__PYQT__ as __PYQT__
-from ibeis.plottool import __MPL_INIT__
+from . import __MPL_INIT__
 __MPL_INIT__.init_matplotlib()
 
 import matplotlib as mpl
 #mpl.use('Qt4Agg')
 import matplotlib.pyplot as plt
 
-from ibeis.plottool import plot_helpers as ph
-from ibeis.plottool import plot_helpers
-from ibeis.plottool import mpl_keypoint
-from ibeis.plottool import mpl_keypoint as mpl_kp
-from ibeis.plottool import mpl_sift as mpl_sift
-from ibeis.plottool import draw_func2
-from ibeis.plottool import draw_func2 as df2
-from ibeis.plottool import fig_presenter
-from ibeis.plottool import custom_constants
-from ibeis.plottool import custom_figure
-from ibeis.plottool import draw_sv
-from ibeis.plottool import viz_featrow
-from ibeis.plottool import viz_keypoints
-from ibeis.plottool import viz_image2
-from ibeis.plottool import plots
-from ibeis.plottool import interact_annotations
-from ibeis.plottool import interact_keypoints
-from ibeis.plottool import interact_multi_image
-from ibeis.plottool import interactions
-from ibeis.plottool import interact_impaint
-from ibeis.plottool import color_funcs
-#from ibeis.plottool import abstract_iteraction
+from . import plot_helpers as ph
+from . import plot_helpers
+from . import mpl_keypoint
+from . import mpl_keypoint as mpl_kp
+from . import mpl_sift as mpl_sift
+from . import draw_func2
+from . import draw_func2 as df2
+from . import fig_presenter
+from . import custom_constants
+from . import custom_figure
+from . import draw_sv
+from . import viz_featrow
+from . import viz_keypoints
+from . import viz_image2
+from . import plots
+from . import interact_annotations
+from . import interact_keypoints
+from . import interact_multi_image
+from . import interactions
+from . import interact_impaint
+from . import color_funcs
+#from . import abstract_iteraction
 
 
 # TODO utoolify this
@@ -63,11 +63,11 @@ IMPORT_TUPLES = [
 
 # The other module shouldn't exist.
 # Functions in it need to be organized
-from ibeis.plottool.plots import draw_hist_subbin_maxima
-#from ibeis.plottool.draw_func2 import *  # NOQA
-from ibeis.plottool.mpl_keypoint import draw_keypoints
-from ibeis.plottool.mpl_sift import draw_sifts, render_sift_on_patch
-from ibeis.plottool import fig_presenter
+from .plots import draw_hist_subbin_maxima
+#from .draw_func2 import *  # NOQA
+from .mpl_keypoint import draw_keypoints
+from .mpl_sift import draw_sifts, render_sift_on_patch
+from . import fig_presenter
 
 import utool
 
@@ -115,24 +115,24 @@ if DOELSE:
     pass
     # <AUTOGEN_INIT>
 
-    from ibeis.plottool import plot_helpers
-    from ibeis.plottool import fig_presenter
-    from ibeis.plottool import custom_constants
-    from ibeis.plottool import custom_figure
-    from ibeis.plottool import plots
-    from ibeis.plottool import draw_func2
-    from ibeis.plottool import interact_impaint
-    from ibeis.plottool import interactions
-    from ibeis.plottool import interact_multi_image
-    from ibeis.plottool import interact_keypoints
-    from ibeis.plottool import interact_matches
-    from ibeis.plottool import nx_helpers
-    from ibeis.plottool.plot_helpers import (SIFT_OR_VECFIELD, del_plotdat, draw,
+    from . import plot_helpers
+    from . import fig_presenter
+    from . import custom_constants
+    from . import custom_figure
+    from . import plots
+    from . import draw_func2
+    from . import interact_impaint
+    from . import interactions
+    from . import interact_multi_image
+    from . import interact_keypoints
+    from . import interact_matches
+    from . import nx_helpers
+    from .plot_helpers import (SIFT_OR_VECFIELD, del_plotdat, draw,
                                        ensureqt, get_bbox_centers,
                                        get_plotdat, get_plotdat_dict,
                                        get_square_row_cols, kp_info, qt4ensure,
                                        set_plotdat,)
-    from ibeis.plottool.fig_presenter import (SLEEP_TIME, VERBOSE,
+    from .fig_presenter import (SLEEP_TIME, VERBOSE,
                                         all_figures_bring_to_front,
                                         all_figures_show,
                                         all_figures_tight_layout,
@@ -145,7 +145,7 @@ if DOELSE:
                                         present, register_qt4_win, reset,
                                         set_geometry, show, show_figure,
                                         unregister_qt4_win, update,)
-    from ibeis.plottool.custom_constants import (BLACK, BLUE, BRIGHT_GREEN,
+    from .custom_constants import (BLACK, BLUE, BRIGHT_GREEN,
                                            BRIGHT_PURPLE, DARK_BLUE,
                                            DARK_GREEN, DARK_ORANGE, DARK_RED,
                                            DARK_YELLOW, DEEP_PINK, DPI,
@@ -162,7 +162,7 @@ if DOELSE:
                                            SMALLEST, TRUE_BLUE, TRUE_GREEN,
                                            UNKNOWN_PURP, WHITE, YELLOW,
                                            golden_wh, golden_wh2,)
-    from ibeis.plottool.custom_figure import (FIGTITLE_SIZE, LABEL_SIZE, LEGEND_SIZE,
+    from .custom_figure import (FIGTITLE_SIZE, LABEL_SIZE, LEGEND_SIZE,
                                         TITLE_SIZE, cla, clf, customize_figure,
                                         customize_fontprop, figure, gca, gcf,
                                         get_ax, get_image_from_figure,
@@ -172,7 +172,7 @@ if DOELSE:
                                         set_figtitle, set_ticks, set_title,
                                         set_xlabel, set_xticks, set_ylabel,
                                         set_yticks, split,)
-    from ibeis.plottool.plots import (colorline, draw_histogram,
+    from .plots import (colorline, draw_histogram,
                                 draw_time_distribution, draw_time_histogram,
                                 draw_timedelta_pie, estimate_pdf,
                                 get_good_logyscale_kwargs, interval_line_plot,
@@ -185,7 +185,7 @@ if DOELSE:
                                 plot_stems, set_logyscale_from_data,
                                 unicode_literals, word_histogram2, wordcloud,
                                 zoom_effect01,)
-    from ibeis.plottool.draw_func2 import (BASE_FNUM, DARKEN, DEBUG, DF2_DIVIDER_KEY,
+    from .draw_func2 import (BASE_FNUM, DARKEN, DEBUG, DF2_DIVIDER_KEY,
                                      FALSE, LEGEND_LOCATION, OffsetImage2,
                                      RenderingContext, SAFE_POS, TAU,
                                      TMP_mevent, TRUE, absolute_lbl, add_alpha,
@@ -240,19 +240,19 @@ if DOELSE:
                                      update_figsize, upperleft_text,
                                      upperright_text, variation_trunctate,
                                      width_from,)
-    from ibeis.plottool.interact_impaint import (PAINTER_BASE, PaintInteraction,
+    from .interact_impaint import (PAINTER_BASE, PaintInteraction,
                                            draw_demo, impaint_mask2,)
-    from ibeis.plottool.interactions import (ExpandableInteraction, PanEvents,
+    from .interactions import (ExpandableInteraction, PanEvents,
                                        check_if_subinteract, pan_factory,
                                        zoom_factory,)
-    from ibeis.plottool.interact_multi_image import (BASE_CLASS, Button,
+    from .interact_multi_image import (BASE_CLASS, Button,
                                                MultiImageInteraction,)
-    from ibeis.plottool.interact_keypoints import (KeypointInteraction,
+    from .interact_keypoints import (KeypointInteraction,
                                              draw_feat_row, ishow_keypoints,
                                              show_keypoints,)
-    from ibeis.plottool.interact_matches import (MatchInteraction2,
+    from .interact_matches import (MatchInteraction2,
                                            show_keypoint_gradient_orientations,)
-    from ibeis.plottool.nx_helpers import (GraphVizLayoutConfig, LARGE_GRAPH,
+    from .nx_helpers import (GraphVizLayoutConfig, LARGE_GRAPH,
                                      apply_graph_layout_attrs, draw_network2,
                                      dump_nx_ondisk, ensure_nonhex_color,
                                      format_anode_pos, get_explicit_graph,

--- a/ibeis/plottool/abstract_interaction.py
+++ b/ibeis/plottool/abstract_interaction.py
@@ -283,8 +283,8 @@ class AbstractInteraction(object):
         if self.debug > 0:
             print('[pt.a] on_release')
         for button in self.MOUSE_BUTTONS.values():
-            flag = (event is None or event.button is None or
-                    self.MOUSE_BUTTONS[event.button] == button)
+            flag = (event is None or event.button is None
+                    or self.MOUSE_BUTTONS[event.button] == button)
             if flag:
                 self.is_down[button] = False
                 if self.is_drag[button]:

--- a/ibeis/plottool/abstract_interaction.py
+++ b/ibeis/plottool/abstract_interaction.py
@@ -11,7 +11,7 @@ import re
 import utool as ut
 import matplotlib as mpl
 ut.noinject(__name__, '[abstract_iteract]')
-import ibeis.plottool.draw_func2 as df2  # NOQA
+from . import draw_func2 as df2  # NOQA
 from ibeis.plottool import fig_presenter  # NOQA
 from ibeis.plottool import plot_helpers as ph  # NOQA
 from ibeis.plottool import interact_helpers as ih  # NOQA

--- a/ibeis/plottool/draw_sv.py
+++ b/ibeis/plottool/draw_sv.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 import utool as ut
 import numpy as np
-import ibeis.plottool.draw_func2 as df2
+from . import draw_func2 as df2
 from ibeis.plottool import custom_constants
 #from vtool_ibeis import keypoint as ktool
 #(print, print_, printDBG, rrr, profile) = ut.inject(__name__, '[viz_sv]', DEBUG=False)

--- a/ibeis/plottool/interact_annotations.py
+++ b/ibeis/plottool/interact_annotations.py
@@ -412,6 +412,7 @@ class AnnotationInteraction(abstract_interaction.AbstractInteraction):
         self.img = img
         self.show_species_tags = True
         self.max_dist = 10
+
         def _reinitialize_variables():
             self.do_mask = do_mask
             self.img_ind = img_ind
@@ -818,8 +819,8 @@ class AnnotationInteraction(abstract_interaction.AbstractInteraction):
             print('[interact_annot] _send_back_annotations')
             indices_list, annottup_list = _get_annottup_list()
             # Delete if index is in original_indices but no in indices_list
-            deleted_indices   = list(set(self.original_indices) -
-                                     set(indices_list))
+            deleted_indices   = list(set(self.original_indices)
+                                     - set(indices_list))
             changed_indices   = []
             unchanged_indices = []  # sanity check
             changed_annottups = []
@@ -1029,9 +1030,9 @@ class AnnotationInteraction(abstract_interaction.AbstractInteraction):
         #    return
 
         quick_resize = (self._poly_held is True and (
-            (event.button == self.MIDDLE_BUTTON) or
-            (event.button == self.RIGHT_BUTTON) or
-            (event.button == self.LEFT_BUTTON and event.key == 'ctrl')
+            (event.button == self.MIDDLE_BUTTON)
+            or (event.button == self.RIGHT_BUTTON)
+            or (event.button == self.LEFT_BUTTON and event.key == 'ctrl')
         ))
 
         if self._poly_held is True and self._ind is not None:
@@ -1076,12 +1077,12 @@ class AnnotationInteraction(abstract_interaction.AbstractInteraction):
             return
 
         _flag = (
-            self._ind is None or
-            self._poly_held is False or
-            (self._ind is not None and
-             self.is_down['left'] is True and
-             self._selected_poly is not None
-             )
+            self._ind is None
+            or self._poly_held is False
+            or (self._ind is not None
+                and self.is_down['left'] is True
+                and self._selected_poly is not None
+                )
         )
         if _flag:
             self._selected_poly.set_alpha(0)
@@ -1148,7 +1149,7 @@ class AnnotationInteraction(abstract_interaction.AbstractInteraction):
             self._selected_poly.set_species(DEFAULT_SPECIES_TAG)
         if re.match('^tab$', event.key):
             self._selected_poly.increment_species(amount=1)
-        if re.match('^ctrl\+tab$', event.key):
+        if re.match(r'^ctrl\+tab$', event.key):
             self._selected_poly.increment_species(amount=-1)
 
         # NEXT ANND PREV COMMAND

--- a/ibeis/plottool/interact_annotations.py
+++ b/ibeis/plottool/interact_annotations.py
@@ -39,7 +39,7 @@ import utool as ut
 import itertools as it
 import matplotlib as mpl
 from six.moves import zip, range
-from ibeis.plottool import draw_func2 as df2
+from . import draw_func2 as df2
 from ibeis.plottool import abstract_interaction
 print, rrr, profile = ut.inject2(__name__)
 

--- a/ibeis/plottool/interact_keypoints.py
+++ b/ibeis/plottool/interact_keypoints.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import utool as ut
 import six
-from ibeis.plottool import draw_func2 as df2
+from . import draw_func2 as df2
 from ibeis.plottool import plot_helpers as ph
 from ibeis.plottool import interact_helpers as ih
 from ibeis.plottool.viz_featrow import draw_feat_row

--- a/ibeis/plottool/interact_multi_image.py
+++ b/ibeis/plottool/interact_multi_image.py
@@ -3,7 +3,7 @@ from six.moves import range
 #import matplotlib.image as mpimg
 from ibeis.plottool import viz_image2
 from ibeis.plottool import interact_annotations
-from ibeis.plottool import draw_func2 as df2
+from . import draw_func2 as df2
 from ibeis.plottool import plot_helpers as ph
 from ibeis.plottool import interact_helpers as ih
 from ibeis.plottool import abstract_interaction

--- a/ibeis/plottool/interactions.py
+++ b/ibeis/plottool/interactions.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 import utool as ut
-import ibeis.plottool as pt
-from ibeis.plottool import abstract_interaction
-import ibeis.plottool.interact_helpers as ih
+from .. import plottool as pt
+from . import abstract_interaction
+from . import interact_helpers as ih
 
 
 def check_if_subinteract(func):

--- a/ibeis/plottool/interactions.py
+++ b/ibeis/plottool/interactions.py
@@ -200,6 +200,7 @@ def zoom_factory(ax=None, zoomable_list=[], base_scale=1.1):
     """
     if ax is None:
         ax = pt.gca()
+
     def zoom_fun(event):
         #print('zooming')
         # get the current x and y limits

--- a/ibeis/plottool/nx_helpers.py
+++ b/ibeis/plottool/nx_helpers.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import, division, print_function
 from six.moves import zip
 import six
 try:
-    import dtool as dt
+    from ibeis import dtool as dt
 except ImportError:
     pass
 import numpy as np

--- a/ibeis/plottool/plot_helpers.py
+++ b/ibeis/plottool/plot_helpers.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 import numpy as np
-# import ibeis.plottool.draw_func2 as df2
+# from . import draw_func2 as df2
 from ibeis.plottool import fig_presenter
 #from ibeis.plottool import custom_figure
 #from ibeis.plottool import custom_constants

--- a/ibeis/plottool/plots.py
+++ b/ibeis/plottool/plots.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import warnings
 from six.moves import zip, range, zip_longest
-from ibeis.plottool import draw_func2 as df2
+from . import draw_func2 as df2
 import six
 from six.moves import reduce
 import scipy.stats

--- a/ibeis/plottool/plots.py
+++ b/ibeis/plottool/plots.py
@@ -296,6 +296,7 @@ def multi_plot(xdata=None, ydata_list=[], **kwargs):
     if transpose:
         #xdata_list = ydata_list
         ydata = xdata
+
         # Hack / Fix any transpose issues
         def transpose_key(key):
             if key.startswith('x'):
@@ -316,6 +317,7 @@ def multi_plot(xdata=None, ydata_list=[], **kwargs):
     title      = kwargs.get('title', None)
     xlabel     = kwargs.get('xlabel', '')
     ylabel     = kwargs.get('ylabel', '')
+
     def none_or_unicode(text):
         return None if text is None else ut.ensure_unicode(text)
 
@@ -1792,6 +1794,7 @@ def interval_stats_plot(param2_stat_dict, fnum=None, pnum=(1, 1, 1), x_label='',
     # Prepare y data for boxplot
     y_data_keys = ['std', 'mean', 'max', 'min']
     y_data_dict = list(six.itervalues(param2_stat_dict))
+
     def get_dictlist_key(dict_list, key):
         return [dict_[key] for dict_ in dict_list]
     y_data_components = [get_dictlist_key(y_data_dict, key) for key in y_data_keys]
@@ -2063,7 +2066,7 @@ def draw_timedelta_pie(timedeltas, bins=None, fnum=None, pnum=(1, 1, 1), label='
     freq = np.histogram(xdata, bins)[0]
     timedelta_strs = [ut.get_timedelta_str(datetime.timedelta(seconds=b), exclude_zeros=True)
                       for b in bins]
-    bin_labels = [l + ' - ' + h for l, h in ut.iter_window(timedelta_strs)]
+    bin_labels = [ll + ' - ' + h for ll, h in ut.iter_window(timedelta_strs)]
     bin_labels[-1] = '> 1 year'
     bin_labels[0] = '< 1 minute'
 
@@ -2376,12 +2379,12 @@ def wordcloud(text, size=None, fnum=None, pnum=None, ax=None):
         font_path = None
 
     colormap = pt.interpolated_colormap([
-            (pt.RED, 0),
-            (pt.PINK, .15),
-            (pt.ORANGE, .3),
-            (pt.GREEN, .55),
-            (pt.TRUE_BLUE, .75),
-            (pt.PURPLE, 1.0),
+        (pt.RED, 0),
+        (pt.PINK, .15),
+        (pt.ORANGE, .3),
+        (pt.GREEN, .55),
+        (pt.TRUE_BLUE, .75),
+        (pt.PURPLE, 1.0),
     ])
 
     if size is None:

--- a/ibeis/plottool/viz_featrow.py
+++ b/ibeis/plottool/viz_featrow.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import utool as ut
 import six
 #import itertools
-import ibeis.plottool.draw_func2 as df2
+from . import draw_func2 as df2
 from ibeis.plottool import plot_helpers as ph
 from ibeis.plottool import custom_constants
 from ibeis.plottool import custom_figure

--- a/ibeis/plottool/viz_featrow.py
+++ b/ibeis/plottool/viz_featrow.py
@@ -138,9 +138,9 @@ def draw_feat_row(chip, fx, kp, sift, fnum, nRows, nCols=None, px=None, prevsift
         ph.set_plotdat(ax, 'aid', aid)
         ph.set_plotdat(ax, 'fx', fx)
         if shape_labels:
-            warped_lbl = ('warped feature\n' +
-                          'fx=%r scale=%.1f\n' +
-                          '%s') % (fx, scale, xy_str)
+            warped_lbl = ('warped feature\n'
+                          + 'fx=%r scale=%.1f\n'
+                          + '%s') % (fx, scale, xy_str)
         else:
             warped_lbl = ''
         warped_lbl += info

--- a/ibeis/plottool/viz_image2.py
+++ b/ibeis/plottool/viz_image2.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 from six.moves import zip, map
 import utool
-import ibeis.plottool.draw_func2 as df2
+from . import draw_func2 as df2
 from ibeis.plottool import custom_constants
 #(print, print_, printDBG, rrr, profile) = utool.inject(__name__, '[viz_img2]', DEBUG=False)
 utool.noinject(__name__, '[viz_img2]')

--- a/ibeis/plottool/viz_keypoints.py
+++ b/ibeis/plottool/viz_keypoints.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 import utool
-import ibeis.plottool.draw_func2 as df2
+from . import draw_func2 as df2
 import numpy as np
 from ibeis.plottool import plot_helpers as ph
 #(print, print_, printDBG, rrr, profile) = utool.inject(__name__, '[viz_keypoints]', DEBUG=False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 # This section configures `flake8`, the python linting utility.
 # See also https://flake8.pycqa.org/en/latest/user/configuration.html
-ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E203,E221,E222,E241,E265,E271,E272,E301,E501,N802,N803,N805,N806
+ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E203,E221,E222,E241,E265,E271,E272,E301,E501,N802,N803,N805,N806,W503
 # D100 - Missing docstring in public module
 # D101 - Missing docstring in public class
 # D102 - Missing docstring in public method
@@ -37,6 +37,31 @@ ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E
 # N806 - variable in function should be lowercase
 # N* codes come from pep8-naming, which integrates with flake8
 # See also https://github.com/PyCQA/pep8-naming#error-codes
+
+# W503 - line break before binary operator
+#
+# The reason for adding W503 to the ignored list is because W503 (Line break
+# occurred before a binary operator) and W504 (Line break occurred after a binary
+# operator) are both enabled in flake8 by default for some reason.  But they are
+# mutually exclusive so one has to be disabled / ignored.
+#
+# According to pep8 at the time of the commit
+# https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
+#
+# ```
+# income = (gross_wages +
+#           taxable_interest +
+#           (dividends - qualified_dividends) -
+#           ira_deduction -
+#           student_loan_interest)
+# income = (gross_wages
+#           + taxable_interest
+#           + (dividends - qualified_dividends)
+#           - ira_deduction
+#           - student_loan_interest)
+# ```
+#
+# W504 (Line break occurred after a binary operator) is the correct behavior.
 
 # Exclude the git directory and virtualenv directory (as `.env`)
 exclude = .git,.env


### PR DESCRIPTION
- Change "import dtool" to "from ibeis import dtool"

  `dtool` was an independent package but has been moved into ibeis so the
  import needs to change from `import dtool` to `from ibeis import dtool`.
  
  ```
  git grep -lE '^\s*import dtool' ibeis | xargs \
      sed -i 's/^\(\s*\)import dtool/\1from ibeis import dtool/'
  ```

- Add W503 line break before operator to ignored flake8 errors

  The reason for adding this to the ignored list is because W503 (Line break
  occurred before a binary operator) and W504 (Line break occurred after a binary
  operator) are both enabled in flake8 by default for some reason.  But they are
  mutually exclusive so one has to be disabled / ignored.
  
  According to pep8 at the time of the commit
  https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
  
  ```
  income = (gross_wages +
            taxable_interest +
            (dividends - qualified_dividends) -
            ira_deduction -
            student_loan_interest)
  income = (gross_wages
            + taxable_interest
            + (dividends - qualified_dividends)
            - ira_deduction
            - student_loan_interest)
  ```
  
  W503 (Line break occurred before a binary operator) is the correct behavior.

- Fix some flake8 errors in ibeis/plottool

  ```
  ibeis/plottool/viz_featrow.py:141:46: W504 line break after binary operator
  ibeis/plottool/viz_featrow.py:142:48: W504 line break after binary operator
  ibeis/plottool/interactions.py:203:5: E306 expected 1 blank line before a nested definition, found 0
  ibeis/plottool/interact_annotations.py:415:9: E306 expected 1 blank line before a nested definition, found 0
  ibeis/plottool/interact_annotations.py:821:65: W504 line break after binary operator
  ibeis/plottool/interact_annotations.py:1032:50: W504 line break after binary operator
  ibeis/plottool/interact_annotations.py:1033:49: W504 line break after binary operator
  ibeis/plottool/interact_annotations.py:1079:31: W504 line break after binary operator
  ibeis/plottool/interact_annotations.py:1080:38: W504 line break after binary operator
  ibeis/plottool/interact_annotations.py:1081:36: W504 line break after binary operator
  ibeis/plottool/interact_annotations.py:1082:43: W504 line break after binary operator
  ibeis/plottool/interact_annotations.py:1151:27: W605 invalid escape sequence '\+'
  ibeis/plottool/plots.py:300:9: E306 expected 1 blank line before a nested definition, found 0
  ibeis/plottool/plots.py:319:5: E306 expected 1 blank line before a nested definition, found 0
  ibeis/plottool/plots.py:1795:5: E306 expected 1 blank line before a nested definition, found 0
  ibeis/plottool/plots.py:2066:37: E741 ambiguous variable name 'l'
  ibeis/plottool/plots.py:2379:13: E126 continuation line over-indented for hanging indent
  ibeis/plottool/abstract_interaction.py:286:59: W504 line break after binary operator
  ```

- Change plottool/__init__.py to use relative imports

  This is to get around circular imports:
  
  ```
  Traceback (most recent call last):
    File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
      "__main__", mod_spec)
    File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
      exec(code, run_globals)
    File "/ibeis/ibeis/ibeis/__main__.py", line 146, in <module>
      run_ibeis()
    File "/ibeis/ibeis/ibeis/__main__.py", line 128, in run_ibeis
      main_locals = ibeis.main()
    File "/ibeis/ibeis/ibeis/main_module.py", line 253, in main
      _preload()
    File "/ibeis/ibeis/ibeis/main_module.py", line 583, in _preload
      _init_matplotlib()
    File "/ibeis/ibeis/ibeis/main_module.py", line 59, in _init_matplotlib
      from ibeis.plottool import __MPL_INIT__
    File "/ibeis/ibeis/ibeis/plottool/__init__.py", line 33, in <module>
      from ibeis.plottool import draw_sv
    File "/ibeis/ibeis/ibeis/plottool/draw_sv.py", line 4, in <module>
      import ibeis.plottool.draw_func2 as df2
  AttributeError: module 'ibeis' has no attribute 'plottool'
  ```

- Change plottool draw_func2 imports to relative imports

  This only changes code inside `ibeis/plottool` that does
  `import ibeis.plottool.draw_func2` or
  `from ibeis.plottool import draw_func2` to fix circular imports:
  
  ```
    File "/ibeis/ibeis/ibeis/__init__.py", line 80, in <module>
      from ibeis.scripts import postdoc
    File "/ibeis/ibeis/ibeis/scripts/postdoc.py", line 3, in <module>
      import ibeis.plottool as pt
    File "/ibeis/ibeis/ibeis/plottool/__init__.py", line 33, in <module>
      from . import draw_sv
    File "/ibeis/ibeis/ibeis/plottool/draw_sv.py", line 4, in <module>
      import ibeis.plottool.draw_func2 as df2
  AttributeError: module 'ibeis' has no attribute 'plottool'
  ```

- Change plottool/interactions to use relative imports

  This fixes circular imports:
  
  ```
    File "/ibeis/ibeis/ibeis/__init__.py", line 80, in <module>
      from ibeis.scripts import postdoc
    File "/ibeis/ibeis/ibeis/scripts/postdoc.py", line 3, in <module>
      import ibeis.plottool as pt
    File "/ibeis/ibeis/ibeis/plottool/__init__.py", line 41, in <module>
      from . import interactions
    File "/ibeis/ibeis/ibeis/plottool/interactions.py", line 4, in <module>
      import ibeis.plottool as pt
  AttributeError: module 'ibeis' has no attribute 'plottool'
  ```