### PR TITLE
Temporarily disable external plugins

### DIFF
--- a/ibeis/control/IBEISControl.py
+++ b/ibeis/control/IBEISControl.py
@@ -101,33 +101,39 @@ AUTOLOAD_PLUGIN_MODNAMES = [
     'ibeis.algo.smk.vocab_indexer',
     'ibeis.algo.smk.smk_pipeline',
 
-    (('--no-cnn', '--nocnn'), 'ibeis_cnn'),
-    (('--no-cnn', '--nocnn'), 'ibeis_cnn._plugin'),
-    (('--no-fluke', '--nofluke'), 'ibeis_flukematch.plugin'),
-    (('--no-curvrank', '--nocurvrank'), 'ibeis_curvrank._plugin'),
+    # FIXME (4-Jun-12020) Temporarily disable external plugins
+    # (('--no-cnn', '--nocnn'), 'ibeis_cnn'),
+    # (('--no-cnn', '--nocnn'), 'ibeis_cnn._plugin'),
+    # (('--no-fluke', '--nofluke'), 'ibeis_flukematch.plugin'),
+    # (('--no-curvrank', '--nocurvrank'), 'ibeis_curvrank._plugin'),
+    # /FIXME
+
     # 'ibeis_plugin_identification_example',
 ]
 
-if ut.get_argflag('--deepsense'):
-    AUTOLOAD_PLUGIN_MODNAMES += [
-        (('--no-deepsense', '--nodeepsense'), 'ibeis_deepsense._plugin'),
-    ]
+# FIXME (4-Jun-12020) Temporarily disable external plugins
 
-if ut.get_argflag('--finfindr'):
-    AUTOLOAD_PLUGIN_MODNAMES += [
-        (('--no-finfindr', '--nofinfindr'), 'ibeis_finfindr._plugin'),
-    ]
+# if ut.get_argflag('--deepsense'):
+#     AUTOLOAD_PLUGIN_MODNAMES += [
+#         (('--no-deepsense', '--nodeepsense'), 'ibeis_deepsense._plugin'),
+#     ]
 
-if ut.get_argflag('--kaggle7') or ut.get_argflag('--kaggleseven'):
-    AUTOLOAD_PLUGIN_MODNAMES += [
-        (('--no-kaggle7', '--nokaggle7', '--no-kaggleseven', '--nokaggleseven'), 'ibeis_kaggle7._plugin'),
-    ]
+# if ut.get_argflag('--finfindr'):
+#     AUTOLOAD_PLUGIN_MODNAMES += [
+#         (('--no-finfindr', '--nofinfindr'), 'ibeis_finfindr._plugin'),
+#     ]
 
-if ut.get_argflag('--orient2d'):
-    AUTOLOAD_PLUGIN_MODNAMES += [
-        (('--no-2d-orient', '--no2dorient'), 'ibeis_2d_orientation._plugin'),
-    ]
+# if ut.get_argflag('--kaggle7') or ut.get_argflag('--kaggleseven'):
+#     AUTOLOAD_PLUGIN_MODNAMES += [
+#         (('--no-kaggle7', '--nokaggle7', '--no-kaggleseven', '--nokaggleseven'), 'ibeis_kaggle7._plugin'),
+#     ]
 
+# if ut.get_argflag('--orient2d'):
+#     AUTOLOAD_PLUGIN_MODNAMES += [
+#         (('--no-2d-orient', '--no2dorient'), 'ibeis_2d_orientation._plugin'),
+#     ]
+
+# /FIXME
 
 """
 # Should import


### PR DESCRIPTION
This is being done to limit the amount of external influencers during
the renaming of ibeis to wbia. The plan will be to bring these back
one at a time after the major rename.

---

Based on our previous discussion, it should be fine to disable these in the short term. Feel free to close if I've misunderstood or you feel this would cause additional issues.